### PR TITLE
Simplified DecodeString()

### DIFF
--- a/string.go
+++ b/string.go
@@ -79,16 +79,9 @@ func DecodeString(words []uint32) string {
 	}
 
 	// Remove any trailing nul bytes.
-	sz := len(out) - 1
-	for ; sz >= 0; sz-- {
-		if out[sz] != 0 {
-			sz++
-			break
-		}
-	}
-
-	if sz <= 0 {
-		return ""
+	sz := len(out)
+	for sz > 0 && out[sz-1] == 0 {
+		sz--
 	}
 
 	return string(out[:sz])


### PR DESCRIPTION
If `sz` is empty, the `out` slice should be a "nil slice", and the output string is empty. I wasn't able to find documentation on string construction from byte slices (or anything, really), so I'm not sure if this is safe, though the tests work fine (specifically, `string_test.go` case 0).